### PR TITLE
Set default background color to white for BrowserWindow.

### DIFF
--- a/main.js
+++ b/main.js
@@ -13,6 +13,7 @@ function createWindow() {
     width: 1080,
     height: 600,
     show: false,
+    backgroundColor: '#ffffff',
   });
 
   mainWindow.loadFile('index.html');


### PR DESCRIPTION
Resolves #13. 